### PR TITLE
Added a Dependabot configuration to the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "06:00"
+    assignees:
+      - "samuelngsh"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "06:00"
+    assignees:
+      - "samuelngsh"


### PR DESCRIPTION
This PR adds a configuration for GitHub's [Dependabot](https://github.com/dependabot) to SiQAD. Dependabot will automatically create PRs whenever one of your git submodules or GitHub Actions is out of date. You can always decide not to merge them though.

In my personal opinion, this feature will help you keep track of plugin updates in a convenient way.