### PR TITLE
:construction_worker: Update ``.gitignore`` and Set C++17 as Default Compiler Standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,40 +1,101 @@
-# specific patterns
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+*.pyc
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# LaTeX files
+*.aux
+*.log
+*.pdf
+*.synctex.gz
+
+# Doxygen files
+*.bak
+doxygen
+
+# Build directories
+cmake-build-*
+build/
+w64-build*/**
+build*/**
+
+# IDE files
+*.directory
+*.idea
+*.vs
+.vscode/
+
+# Experiment files
+*.json
+*.csv
+
+# Coverage files
+lcov.info
+
+# Python
+__pycache__
+venv/
+*.egg-info
+*.env
+.ycm*.py
+
+# Archive files
+*.zip
+*.tar.*
+*.7z
+*.rar
+
+# Specific patterns
 moc_*
 db-sim
 
 # macOS
 .DS_Store
 
-# compiled source
-*.o
-*.pyc
-qrc_application.cpp
-/w64-build*/**
-/build*/**
-win32
-win64
-
-# logs and databases
+# Logs and databases
 src/log/
-*.log
 Makefile
 
-#documentation
-doxygen
-
-#PoissonSolver outputs
+# PoissonSolver outputs
 *outfile.txt
 *outrho.txt
 *outcorr.txt
 
-#save files
+# Save files
 /*.xml
 *.sqd
 
-# other
+# Other
 *.swp
 .qmake.stash
 tempfig.pdf
 .temp/
-.vscode/
-.ycm*.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
+# Only set the CMAKE_CXX_STANDARD if it is not set by someone else
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    # Set C++ standard; at least C++17 is required
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # It is highly recommended not to run cmake in this directory. Create a `build`
 # directory first and run `cmake [OPTIONS] ..`.
 # Add flag `-DCMAKE_BUILD_TYPE=Release` (without back-ticks) for release builds.


### PR DESCRIPTION
This PR updates the .gitignore to exclude common C++ build artifacts and sets C++17 as the default compiler standard. These changes help maintain a clean codebase and leverage modern C++ features.