### PR TITLE
:dependabot: Replace the old submodule name (``quicksim-siqad-plugin``) with the current one (``mnt-siqad-plugins``)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,6 @@
 [submodule "src/libs/zipper"]
 	path = src/libs/zipper
 	url = https://github.com/sebastiandev/zipper
-[submodule "plugins/quicksim-siqad-plugin"]
-	path = plugins/quicksim-siqad-plugin
-	url = https://github.com/cda-tum/quicksim-siqad-plugin
+[submodule "plugins/mnt-siqad-plugins"]
+	path = plugins/mnt-siqad-plugins
+	url = https://github.com/cda-tum/mnt-siqad-plugins


### PR DESCRIPTION
This PR replaces the old submodule name (``quicksim-siqad-plugin``) with the new one (``mnt-siqad-plugins``) to avoid confusion. 